### PR TITLE
set node v7.10.1 as minimal, not only one allowed

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/hbi99"
   },
   "engines": {
-    "node": "7.10.1"
+    "node": ">=7.10.1"
   },
   "keywords": [
     "search",


### PR DESCRIPTION
It's now installable via yarn only with node v7.10.1, I've set it as minimal