### PR TITLE
Solve search with parameter single=true and no results

### DIFF
--- a/src/defiant.js
+++ b/src/defiant.js
@@ -653,7 +653,7 @@
 					mapIndex,
 					i;
 
-				if (single) xres = [xres];
+				if (single) xres = (xres == null) ? [] : [xres];
 				i = xres.length;
 
 				while (i--) {


### PR DESCRIPTION
When doing a defiant.search with the option single=true and no results found throws an exception: xres[i] is null. This commit solves the problem.
Sample code:
(async () => {
  // import 'defiant'
  var defiant = await fetchScript('/res/js/modules/defiant.js');
  var data = {
      "car": [
          {"id": 10, "color": "silver", "name": "Volvo"},
          {"id": 11, "color": "red",    "name": "Saab"},
          {"id": 12, "color": "red",    "name": "Peugeot"},
          {"id": 13, "color": "yellow", "name": "Porsche"}
      ],
      "bike": [
          {"id": 20, "color": "black", "name": "Cannondale"},
          {"id": 21, "color": "red",   "name": "Shimano"}
      ]
  };
  

 //Search with 0 results looking for a single node
  var search = defiant.search(data, '//car[color="brown"]/name', true);
  console.log(search);
})();