### PR TITLE
Allow passthrough of puppeteer options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 
 const defiant = {
-	init: async () => {
+	init: async (puppeteerOpts) => {
 		const puppeteer = require('puppeteer')
 		const fs = require('fs')
 		const script = fs.readFileSync(__dirname +'/dist/defiant.min.js', 'utf8')
 
 		return new Promise((resolve, reject) => {
 			puppeteer
-				.launch()
+				.launch(puppeteerOpts)
 				.then(async browser => {
 					const page = await browser.newPage()
 					page.on('console', msg => console.log(msg.text()))


### PR DESCRIPTION
Changes to allow for puppeteer options to be passed through to `defiant.init()` for more control of chromium (https://github.com/hbi99/defiant.js/issues/122)